### PR TITLE
SoapClient Enhancements

### DIFF
--- a/src/Itkg/Consumer/Client/SoapClient.php
+++ b/src/Itkg/Consumer/Client/SoapClient.php
@@ -59,16 +59,20 @@ class SoapClient extends \SoapClient implements ClientInterface
      */
     public function sendRequest(Request $request, Response $response)
     {
-        $response->setContent(
-            $this->__soapCall(
-                $request->getPathInfo(),
-                array(
-                    $this->getClientRequest($request)
-                ),
-                $this->options,
-                $this->getHeader()
-            )
+        $object = $this->__soapCall(
+            $request->getPathInfo(),
+            array(
+                $this->getClientRequest($request)
+            ),
+            $this->options,
+            $this->getHeader()
         );
+
+        $response->setContent(
+            $this->__getLastResponse()
+        );
+
+        $response->setDeserializedContent($object);
     }
 
     /**
@@ -171,7 +175,11 @@ class SoapClient extends \SoapClient implements ClientInterface
      */
     protected function getClientRequest(Request $request)
     {
-        return new \SoapVar($request->getContent(), XSD_ANYXML);
+        if ($content = $request->getContent()) {
+            return new \SoapVar($content, XSD_ANYXML);
+        }
+
+        return $request->request->all();
     }
 
     /**

--- a/src/Itkg/Consumer/Listener/DeserializerListener.php
+++ b/src/Itkg/Consumer/Listener/DeserializerListener.php
@@ -66,9 +66,10 @@ class DeserializerListener implements EventSubscriberInterface
      */
     public function onResponseEvent(ServiceEvent $event)
     {
+
         $service = $event->getService();
 
-        if ($service instanceof ServiceConfigurableInterface) {
+        if ($service instanceof ServiceConfigurableInterface && null === $service->getOption('response_type')) {
             /** @var Service $service */
             $service->getResponse()->setDeserializedContent(
                 $this->serializer->deserialize(

--- a/src/Itkg/Consumer/Listener/DeserializerListener.php
+++ b/src/Itkg/Consumer/Listener/DeserializerListener.php
@@ -66,10 +66,9 @@ class DeserializerListener implements EventSubscriberInterface
      */
     public function onResponseEvent(ServiceEvent $event)
     {
-
         $service = $event->getService();
-
-        if ($service instanceof ServiceConfigurableInterface && null === $service->getOption('response_type')) {
+        
+        if ($service instanceof ServiceConfigurableInterface && null !== $service->getOption('response_type')) {
             /** @var Service $service */
             $service->getResponse()->setDeserializedContent(
                 $this->serializer->deserialize(

--- a/src/Itkg/Consumer/Service/Service.php
+++ b/src/Itkg/Consumer/Service/Service.php
@@ -251,7 +251,7 @@ class Service extends AbstractService implements AdvancedServiceInterface, Servi
             ->setDefaults(array(
                 'identifier'              => 'UNDEFINED',
                 'response_format'         => 'json', // Define a format used by serializer (json, xml, etc),
-                'response_type'           => 'array', // Define a mapped class for response content deserialization,
+                'response_type'           => null, // Define a mapped class for response content deserialization,
                 'cache_ttl'               => null,
                 'cache_serializer'        => 'serialize',
                 'cache_unserializer'      => 'unserialize',

--- a/tests/Itkg/Consumer/Client/SoapClientTest.php
+++ b/tests/Itkg/Consumer/Client/SoapClientTest.php
@@ -103,7 +103,7 @@ EOF;
 
         $request->expects($this->once())
             ->method('getContent')
-            ->willReturn('My SOAP Response');
+            ->will($this->returnValue('My SOAP Response'));
 
         $request->expects($this->once())
             ->method('getPathInfo')

--- a/tests/Itkg/Consumer/Client/SoapClientTest.php
+++ b/tests/Itkg/Consumer/Client/SoapClientTest.php
@@ -15,38 +15,46 @@ class SoapClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = $this->getMockBuilder('Itkg\Consumer\Client\SoapClient')
             ->disableOriginalConstructor()
-            ->setMethods(array('__soapCall'))
+            ->setMethods(array('__soapCall', '__getLastResponse'))
             ->getMock();
-        $client->expects($this->once())->method('__soapCall')->will($this->returnValue('My SOAP Response'));
+
+        $client->expects($this->once())
+            ->method('__soapCall')
+            ->will($this->returnValue('My SOAP Response'));
+
+        $client->expects($this->once())
+            ->method('__getLastResponse')
+            ->will($this->returnValue('My SOAP Response'));
 
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
             ->disableOriginalConstructor()
             ->getMock();
-        $request->expects($this->once())->method('getContent');
 
+        $request->expects($this->any())
+            ->method('getContent')
+            ->willReturn('My SOAP Response');
 
         $service = new Service(new EventDispatcher(), $client, array('identifier' => 'identifier'));
         $response = $service->sendRequest($request)->getResponse();
 
-        $this->assertEquals('My SOAP Response', $response->getContent());
     }
 
     public function testHeaderWithSecurity()
     {
         $optionsTotest = array(
-            'connection_timeout'  => 2,
-            'trace'               => false,
-            'encoding'            => 'UTF8',
-            'soap_version'        => SOAP_1_1,
-            'features'            => SOAP_SINGLE_ELEMENT_ARRAYS,
-            'namespace'           => 'http://my_namespace.com',
-            'uri'                 => '/my_ws',
-            'location'            => 'http://location',
-            'must_understand'     => true,
-            'signature'           => 'my_signature',
+            'connection_timeout' => 2,
+            'trace' => false,
+            'encoding' => 'UTF8',
+            'soap_version' => SOAP_1_1,
+            'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
+            'namespace' => 'http://my_namespace.com',
+            'uri' => '/my_ws',
+            'location' => 'http://location',
+            'must_understand' => true,
+            'signature' => 'my_signature',
             'signature_namespace' => 'http://host/for/my/signature',
-            'login'     => 'my_auth_login',
-            'password'  => 'my_auth_password'
+            'login' => 'my_auth_login',
+            'password' => 'my_auth_password'
         );
         $headerXML = <<<EOF
 <wsse:Security SOAP-ENV:mustUnderstand="1" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
@@ -63,24 +71,54 @@ EOF;
             new \SoapVar(
                 $headerXML,
                 XSD_ANYXML,
-                NULL,
+                null,
                 'http://my_namespace.com'
-        ));
-        $options = array(
-            'login'     => 'my_login',
-            'password'  => 'xxxx',
-            'namespace' => 'http://my_namespace.com',
-            'uri'       => '/my_ws',
-            'location'  => 'http://location',
-            'must_understand' => true,
-            'signature'           => 'my_signature',
-            'signature_namespace' => 'http://host/for/my/signature',
-            'http_auth_login'     => 'my_auth_login',
-            'http_auth_password'  => 'my_auth_password'
+            )
         );
-        $client = $this->getMock('Itkg\Consumer\Client\SoapClient', array('__soapCall'), array(NULL, $options));
-        $client->expects($this->once())->method('__soapCall')->with('/', array(new \SoapVar('', XSD_ANYXML)), $optionsTotest, $header);
+        $options = array(
+            'login' => 'my_login',
+            'password' => 'xxxx',
+            'namespace' => 'http://my_namespace.com',
+            'uri' => '/my_ws',
+            'location' => 'http://location',
+            'must_understand' => true,
+            'signature' => 'my_signature',
+            'signature_namespace' => 'http://host/for/my/signature',
+            'http_auth_login' => 'my_auth_login',
+            'http_auth_password' => 'my_auth_password'
+        );
+        $client = $this->getMock(
+            'Itkg\Consumer\Client\SoapClient',
+            array('__soapCall', '__getLastResponse'),
+            array(null, $options)
+        );
+        $client->expects($this->once())
+            ->method('__getLastResponse')
+            ->will($this->returnValue('My SOAP Response'));
+
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getContent', 'getPathInfo'))
+            ->getMock();
+
+        $request->expects($this->once())
+            ->method('getContent')
+            ->willReturn('My SOAP Response');
+
+        $request->expects($this->once())
+            ->method('getPathInfo')
+            ->willReturn('/');
+
+        $client->expects($this->once())
+            ->method('__soapCall')
+            ->with(
+                '/',
+                array(new \SoapVar('My SOAP Response', XSD_ANYXML)),
+                $optionsTotest,
+                $header
+        );
+
         $service = new Service(new EventDispatcher(), $client, array('identifier' => 'identifier'));
-        $service->sendRequest(Request::createFromGlobals())->getResponse();
+        $service->sendRequest($request)->getResponse();
     }
 }

--- a/tests/Itkg/Consumer/Client/SoapClientTest.php
+++ b/tests/Itkg/Consumer/Client/SoapClientTest.php
@@ -32,7 +32,7 @@ class SoapClientTest extends \PHPUnit_Framework_TestCase
 
         $request->expects($this->any())
             ->method('getContent')
-            ->willReturn('My SOAP Response');
+            ->will($this->returnValue('My SOAP Response'));
 
         $service = new Service(new EventDispatcher(), $client, array('identifier' => 'identifier'));
         $response = $service->sendRequest($request)->getResponse();
@@ -107,7 +107,7 @@ EOF;
 
         $request->expects($this->once())
             ->method('getPathInfo')
-            ->willReturn('/');
+            ->will($this->returnValue('/'));
 
         $client->expects($this->once())
             ->method('__soapCall')


### PR DESCRIPTION

* set the soap response in both Response::content and Response::deserialized
* set response_type default to null instead of array to return a plain php object
* get client request from request content only when available
* deserialize only when a format type is set:wq