### PR TITLE
better soap call caching

### DIFF
--- a/src/Itkg/Consumer/Service/Service.php
+++ b/src/Itkg/Consumer/Service/Service.php
@@ -70,7 +70,8 @@ class Service extends AbstractService implements AdvancedServiceInterface, Servi
         $event = new ServiceEvent($this);
         $this->eventDispatcher->dispatch(ServiceEvents::REQUEST, $event);
 
-        if ('' === $this->response->getContent()) {
+        // check if content has been loaded by some one
+        if (!$this->isLoaded() && '' === $this->response->getContent()) {
             try {
                 $this->client->sendRequest($this->request, $this->response);
             } catch (\Exception $e) {


### PR DESCRIPTION
Check if response has been set by a some one, doesn't test content be… cause soap content is empty if trace not enabled.